### PR TITLE
use TM_PROJECT_DIRECTORY as CT_PROJECT_ROOT

### DIFF
--- a/CTags.tmbundle/Support/bootstrap.php
+++ b/CTags.tmbundle/Support/bootstrap.php
@@ -3,14 +3,17 @@
 define('DS', DIRECTORY_SEPARATOR);
 define('BUNDLE_SUPPORT', __DIR__ . DS);
 
-if (! isset($_SERVER['CT_PROJECT_ROOT'])) {
-	throw new Exception(
-		'You must set the \'CT_PROJECT_ROOT\' '
-		. 'environment variable in your Project.');
+if (isset($_SERVER['CT_PROJECT_ROOT'])) {
+	define('CT_PROJECT_ROOT', rtrim($_SERVER['CT_PROJECT_ROOT'], DS) . DS);
+} else if (isset($_SERVER['TM_PROJECT_DIRECTORY'])) {
+	define('CT_PROJECT_ROOT', rtrim($_SERVER['TM_PROJECT_DIRECTORY'], DS) . DS);
+} else {
+  throw new Exception(
+	'You must set the \'CT_PROJECT_ROOT\' '
+	. 'environment variable in your Project.');
 }
 
 // Shorthand for the project root.
-define('CT_PROJECT_ROOT', rtrim($_SERVER['CT_PROJECT_ROOT'], DS) . DS);
 
 require_once implode(DS, array(
 	__DIR__,

--- a/CTags.tmbundle/Support/update_tags.php
+++ b/CTags.tmbundle/Support/update_tags.php
@@ -2,8 +2,9 @@
 
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
+
 $cmd = implode(' ', array(
-	escapeshellcmd(BUNDLE_SUPPORT . 'bin' . DS . 'ctags'),
+	escapeshellarg(BUNDLE_SUPPORT . 'bin' . DS . 'ctags'),
 	'-f',
 	escapeshellarg(CT_PROJECT_ROOT . 'tmtags'),
 	'--fields=Kn',

--- a/CTags.tmbundle/Support/views/tag.php
+++ b/CTags.tmbundle/Support/views/tag.php
@@ -4,6 +4,8 @@
 		'line' => isset($tag->line) ? $tag->line : null,
 		'title' => $tag->file,
 	)); ?>
+		<span class="file"><?php echo $tag->file; ?></span>
+		<br />
 		<span class="name"><?php echo $tag->name; ?></span>
 <?php if (isset($tag->line)) { ?>
 		<br />


### PR DESCRIPTION
When CT_PROJECT_ROOT is not set we can use `TM_PROJECT_DIRECTORY` which
most likely is the thing we want when we have a project open.

Also when the bundle is saved in a folder with spaces we need to escape
the shell arg for the folder name.
